### PR TITLE
Solving the number of sets error

### DIFF
--- a/src/components/ExerciseCard.jsx
+++ b/src/components/ExerciseCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState,useEffect } from 'react'
 
 export default function ExerciseCard(props) {
     const { exercise, i } = props
@@ -8,6 +8,10 @@ export default function ExerciseCard(props) {
     function handleSetIncrement() {
         setSetsComplete((setsCompleted + 1) % 6)
     }
+
+    useEffect(()=>{
+        setSetsComplete(0);
+    },[exercise])
 
     return (
         <div className='p-4 rounded-md flex flex-col gap-4 bg-slate-950 sm:flex-wrap'>


### PR DESCRIPTION
### Bug:
Number of sets were not being reset to their original position (like i did 2 sets of exercise 1) and then in generator menu changed my options a bit and formulated some other exercises, the exercise card 1 as i did previously 2 sets of it out of 5, it remained unchanged like 2/5 even the exercises changed. 
### Correction:
So i corrected it using a simple useEffect hook which reset the number of sets when exercise object changed. 
### Important Information:
This error is also on your live website **https://swolenormous.smoljames.com** so i thought it will be worth it to discuss with you. Btw amazing project, taught me react & tailwind effectively 👍🏻.